### PR TITLE
Option to only check modified files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mypy action
 
-Run Mypy and add annotate code with errors.
+Run Mypy and annotate code with errors.
 
 ## Inputs
 
@@ -15,6 +15,12 @@ Run Mypy and add annotate code with errors.
 ### `paths`
 
 **Required** An optional space separated list of paths to run Mypy on
+
+### `diff-against-branch`
+
+Specify a branch that will be used as a reference branch. Only .py files that
+have been modified from that branch will be checked. If this option is
+specified the `paths` option is ignored.
 
 ## Usage
 
@@ -41,4 +47,17 @@ this command and commit the modified files in the `dist/` directory:
 
 ```bash
 yarn run package
+```
+
+## Release a new version
+
+```sh
+git checkout -b releases/v1
+git commit -a -m "Release v1.0.0"
+git push origin releases/v1
+git tag v1.0.0
+git push origin v1.0.0
+# Remember to also update the major version tag
+git tag -f v1 -m "Update v1 tag"
+git push origin v1 --force
 ```

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: "Paths to run mypy on"
     default: "."
   diff-against-branch:
-    description: "Only lint files that have been modified from the given branch"
+    description: "Only check files that have been modified from the given branch"
 outputs:
   num-errors: 
     description: 'Number of errors reported'

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,8 @@ inputs:
   paths:
     description: "Paths to run mypy on"
     default: "."
+  diff-against-branch:
+    description: "Only lint files that have been modified from the given branch"
 outputs:
   num-errors: 
     description: 'Number of errors reported'

--- a/dist/index.js
+++ b/dist/index.js
@@ -843,6 +843,27 @@ async function submitResult(githubToken, octokit, conclusion, annotations) {
   }
 }
 
+async function getModifiedPythonFiles(againstBranch) {
+  const files = [];
+  const addFile = file => {
+    if (file.endsWith(".py")) {
+      files.push(file);
+    }
+  };
+
+  const options = {
+    listeners: {
+      stdline: addFile
+    },
+    ignoreReturnCode: false,
+    silent: true
+  };
+
+  await exec.exec("git", ["diff", againstBranch, "--name-only"], options);
+
+  return files;
+}
+
 async function run() {
   try {
     const maxErrors = parseInt(
@@ -854,7 +875,11 @@ async function run() {
     const githubToken = core.getInput("github-token", { required: true });
     const octokit = new github.GitHub(githubToken);
 
-    const paths = (core.getInput("paths") || ".").split(" ");
+    const diffAgainstBranch = core.getInput("diff-against-branch");
+
+    const paths = diffAgainstBranch
+      ? await getModifiedPythonFiles(diffAgainstBranch)
+      : (core.getInput("paths") || ".").split(" ");
 
     const regex = /^(?<file>[^:]+):(?<line>\d+):(?<column>\d+): (?<type>\w+): (?<message>.*)\s+\[(?<error_code>[a-z-]+)\]$/;
     const annotations = [];

--- a/dist/index.js
+++ b/dist/index.js
@@ -817,7 +817,7 @@ async function submitResult(githubToken, octokit, conclusion, annotations) {
   // Create the check run and the first 50 annotations
   const result = await octokit.checks.create({
     ...github.context.repo,
-    name: "MyPy",
+    name: "Mypy",
     head_sha: github.context.sha,
     completed_at: new Date().toISOString(),
     conclusion: conclusion,
@@ -855,8 +855,8 @@ async function getModifiedPythonFiles(againstBranch) {
     listeners: {
       stdline: addFile
     },
-    ignoreReturnCode: false,
-    silent: true
+    ignoreReturnCode: false
+    // silent: true
   };
 
   await exec.exec("git", ["diff", againstBranch, "--name-only"], options);
@@ -890,6 +890,12 @@ async function run() {
       // Skip lines that do not match
       if (match === null) {
         console.log("Unable to parse line:", line);
+        return;
+      }
+
+      // If we're diffing against a reference branch, ignore any errors in
+      // files that have not been modified.
+      if (diffAgainstBranch && !paths.includes(match.groups.file)) {
         return;
       }
 

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ async function submitResult(githubToken, octokit, conclusion, annotations) {
   // Create the check run and the first 50 annotations
   const result = await octokit.checks.create({
     ...github.context.repo,
-    name: "MyPy",
+    name: "Mypy",
     head_sha: github.context.sha,
     completed_at: new Date().toISOString(),
     conclusion: conclusion,
@@ -62,8 +62,8 @@ async function getModifiedPythonFiles(againstBranch) {
     listeners: {
       stdline: addFile
     },
-    ignoreReturnCode: false,
-    silent: true
+    ignoreReturnCode: false
+    // silent: true
   };
 
   await exec.exec("git", ["diff", againstBranch, "--name-only"], options);

--- a/index.js
+++ b/index.js
@@ -50,6 +50,27 @@ async function submitResult(githubToken, octokit, conclusion, annotations) {
   }
 }
 
+async function getModifiedPythonFiles(againstBranch) {
+  const files = [];
+  const addFile = file => {
+    if (file.endsWith(".py")) {
+      files.push(file);
+    }
+  };
+
+  const options = {
+    listeners: {
+      stdline: addFile
+    },
+    ignoreReturnCode: false,
+    silent: true
+  };
+
+  await exec.exec("git", ["diff", againstBranch, "--name-only"], options);
+
+  return files;
+}
+
 async function run() {
   try {
     const maxErrors = parseInt(
@@ -61,7 +82,11 @@ async function run() {
     const githubToken = core.getInput("github-token", { required: true });
     const octokit = new github.GitHub(githubToken);
 
-    const paths = (core.getInput("paths") || ".").split(" ");
+    const diffAgainstBranch = core.getInput("diff-against-branch");
+
+    const paths = diffAgainstBranch
+      ? await getModifiedPythonFiles(diffAgainstBranch)
+      : (core.getInput("paths") || ".").split(" ");
 
     const regex = /^(?<file>[^:]+):(?<line>\d+):(?<column>\d+): (?<type>\w+): (?<message>.*)\s+\[(?<error_code>[a-z-]+)\]$/;
     const annotations = [];

--- a/index.js
+++ b/index.js
@@ -100,6 +100,12 @@ async function run() {
         return;
       }
 
+      // If we're diffing against a reference branch, ignore any errors in
+      // files that have not been modified.
+      if (diffAgainstBranch && !paths.includes(match.groups.file)) {
+        return;
+      }
+
       annotations.push({
         path: match.groups.file,
         start_line: parseInt(match.groups.line, 10),


### PR DESCRIPTION
Add an option to only check files that have been modified against a reference branch. Any errors reported for other files are ignored, and the `path` option is also ignored.